### PR TITLE
Fixed error that required "interval" argument in the bmd function to …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bmd
 Type: Package
 Title: Benchmark dose estimation for dose-response data
-Version: 2.6.3
+Version: 2.6.4
 Date: 2024-09-16
 Author: Signe M.Jensen, Christian Ritz and Jens Riis Baalkilde
 Maintainer: Signe M. Jensen <smj@plen.ku.dk>

--- a/R/bmd.R
+++ b/R/bmd.R
@@ -23,11 +23,11 @@ bmd<-function(object, bmr, backgType = c("modelBased", "absolute", "hybridSD", "
   
   level <- 1-2*(1-level)
   
+  interval <- match.arg(interval)
   if(interval == "sandwich"){
     sandwich.vcov <- TRUE
     interval <- "delta"
   }
-  interval <- match.arg(interval)
   respTrans <- match.arg(respTrans)
   # if(!identical(respTrans, "none") & (def %in% c("hybridExc","hybridAdd"))){
   #   stop(paste("Transformed response not available when using the hybrid method.", sep=""))


### PR DESCRIPTION
…be set manually. "delta" used to be the default, but a minor error meant that it needed to be set manually. Now, "delta" is the default again.